### PR TITLE
Update MarbleItUp.asl

### DIFF
--- a/MarbleItUp.asl
+++ b/MarbleItUp.asl
@@ -157,7 +157,14 @@ update
 
 start
 {
-	return !old.Loading && current.Loading && current.Level == "Learning To Roll";
+	return !old.Loading && current.Loading && (
+		current.Level == "Learning To Roll" ||
+		current.Level == "Duality" ||
+		current.Level == "Sugar Rush" ||
+		current.Level == "Bumper Invasion" ||
+		current.Level == "Newton's Cradle" ||
+		current.Level == "Danger Zone"
+	);
 }
 
 split


### PR DESCRIPTION
Allow the first level of any chapter to start livesplit so chapter RTA runs will auto-start.