### PR TITLE
Change treasure splits to off by default for miuu

### DIFF
--- a/MarbleItUp+Ultra.asl
+++ b/MarbleItUp+Ultra.asl
@@ -279,7 +279,7 @@ startup
             settings.Add("miuu-" + level, true, level, "miuu-" + chapter.Key);
                 settings.Add("miuu-" + level + "-start", true, "Start", "miuu-" + level);
                 settings.Add("miuu-" + level + "-complete", true, "Split on completion", "miuu-" + level);
-                settings.Add("miuu-" + level + "-treasure", true, "Split on Treasure Box collection", "miuu-" + level);
+                settings.Add("miuu-" + level + "-treasure", false, "Split on Treasure Box collection", "miuu-" + level);
         }
     }
 


### PR DESCRIPTION
This better suits RTA runs. Users can always turn them back on. But the default should be off.